### PR TITLE
Timestamps and Nanoseconds added

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -39,12 +39,12 @@ type DataItem struct {
 type DataItems []DataItem
 
 // Convert key/value pairs to DataItems using ConvertValue().
-// Each DataItem's Host is set to hostname, Timestamp is zeroed.
-func MakeDataItems(kv map[string]interface{}, hostname string) DataItems {
+// Each DataItem's Host is set to hostname, in case Timestamp is 0 - it gonna be omitted.
+func MakeDataItems(kv map[string]interface{}, hostname string, timestamp time.Time) DataItems {
 	di := make(DataItems, len(kv))
 	i := 0
 	for k, v := range kv {
-		di[i] = DataItem{hostname, k, 0, ConvertValue(v)}
+		di[i] = DataItem{hostname, k, timestamp.Unix(), ConvertValue(v)}
 		i++
 	}
 

--- a/converter.go
+++ b/converter.go
@@ -62,8 +62,8 @@ func (di DataItems) Marshal() (b []byte, err error) {
 		// the order of fields in this "JSON" is important - request should be before data
 		now := fmt.Sprint(time.Now().Unix())
 		nowNs := fmt.Sprint(time.Now().Nanosecond())
-		datalen := uint64(len(d) + len(now) + 42) // 32 + d + 9 + now + 1
-		b = make([]byte, 0, datalen+13)           // datalen + 5 + 8
+		datalen := uint64(len(d) + len(now) + len(nowNs) + 48) // 32 + d + 9 + now + 6 + nowNs + 1
+		b = make([]byte, 0, datalen+13)                        // datalen + 5 + 8
 		buf := bytes.NewBuffer(b)
 		buf.Write(header)                                     // 5
 		err = binary.Write(buf, binary.LittleEndian, datalen) // 8
@@ -71,7 +71,7 @@ func (di DataItems) Marshal() (b []byte, err error) {
 		buf.Write(d)                                          // d
 		buf.WriteString(`,"clock":`)                          // 9
 		buf.WriteString(now)                                  // now
-		buf.WriteString(`,"ns":`)
+		buf.WriteString(`,"ns":`)                             // 6
 		buf.WriteString(nowNs)
 		buf.WriteByte('}') // 1
 		b = buf.Bytes()

--- a/converter_test.go
+++ b/converter_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 var (
@@ -17,14 +18,14 @@ var (
 	f64  float64 = 3.141592653
 	i    int     = 42
 	s    string  = "string"
-	e    error   = fmt.Errorf("error")
+	e    error   = fmt.Errorf("%v", "error")
 	p0   *string
 	data = map[string]interface{}{"f0": f0, "f1": f1, "float32": f32, "float64": f64,
 		"int": i, "s": s, "e": e, "p0": p0}
 )
 
 func TestMakeDataItems(t *testing.T) {
-	di := MakeDataItems(data, "localhost")
+	di := MakeDataItems(data, "localhost", time.Unix(0, 0), time.Unix(0, 0))
 	t.Logf("%+v", di)
 	for _, d := range di {
 		if d.Hostname != "localhost" {
@@ -73,12 +74,13 @@ func TestMakeDataItems(t *testing.T) {
 }
 
 func TestMarshal(t *testing.T) {
-	di := MakeDataItems(data, "localhost")
+	di := MakeDataItems(data, "localhost", time.Now(), time.Now())
 	b, err := di.Marshal()
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("%s", b)
+
 	if len(b) != cap(b) {
 		t.Errorf("Optimize: len(%d) != cap(%d)", len(b), cap(b))
 	}

--- a/sender_test.go
+++ b/sender_test.go
@@ -5,11 +5,12 @@ import (
 	"net"
 
 	. "."
+	"time"
 )
 
 func ExampleSend() {
 	data := map[string]interface{}{"rpm": 42.12, "errors": 1}
-	di := MakeDataItems(data, "localhost")
+	di := MakeDataItems(data, "localhost", time.Now(), time.Now())
 	addr, _ := net.ResolveTCPAddr("tcp", "localhost:10051")
 	res, _ := Send(addr, di)
 	fmt.Print(res)


### PR DESCRIPTION
Implemented little updates from 3.x version of protocols (added nanoseconds) and made it possible to work with timestamps+ns of each DataItem as it must be. 